### PR TITLE
try restricting recipes in non-main branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
 
     - name: restrict number of built recipes
-      if: ${{ (github.ref != 'refs/heads/main') }}
+      if: "(${{ (github.ref != 'refs/heads/main') }}  && !contains(github.event.head_commit.message, '[build all recipes]')"
       run: |
         # For testing, use BIOCONDA_FILTER_RECIPES=10 or some small-ish number,
         # or BIOCONDA_FILTER_RECIPES=".*" or other regex. If these are set,
@@ -39,9 +39,6 @@ jobs:
         # export BIOCONDA_FILTER_RECIPES=10
         echo "BIOCONDA_FILTER_RECIPES=10" >> $GITHUB_ENV
 
-    - name: override built recipe restriction with [build all recipes]
-      if: "contains(github.event.head_commit.message, '[build all recipes]'"
-        echo "BIOCONDA_FILTER_RECIPES=" >> $GITHUB_ENV
 
     - name: build docs
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
           --channel bioconda \
           --strict-channel-priority
 
+
     - name: restrict number of built recipes
       if: ${{ (github.ref != 'refs/heads/main') }}
       run: |
@@ -41,6 +42,7 @@ jobs:
     - name: build docs
       run: |
         eval "$(conda shell.bash hook)"
+        echo nonexistent is "${{env.NONEXISTENT}}"
         export BIOCONDA_FILTER_RECIPES=${{env.BIOCONDA_FILTER_RECIPES}}
         conda activate ./env
         make clean html SPHINXOPTS="-T -j1"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       if: >-
         ${{
           (github.ref != 'refs/heads/main') &&
-          (!contains(github.event.head_commit.message, '[build all recipes]')
+          (!contains(github.event.head_commit.message, '[build all recipes]'))
         }}
       run: |
         # For testing, use BIOCONDA_FILTER_RECIPES=10 or some small-ish number,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,11 @@ jobs:
 
 
     - name: restrict number of built recipes
-      if: "(${{ (github.ref != 'refs/heads/main') }}  && !contains(github.event.head_commit.message, '[build all recipes]')"
+      if: >-
+        ${{
+          (github.ref != 'refs/heads/main') &&
+          (!contains(github.event.head_commit.message, '[build all recipes]')
+        }}
       run: |
         # For testing, use BIOCONDA_FILTER_RECIPES=10 or some small-ish number,
         # or BIOCONDA_FILTER_RECIPES=".*" or other regex. If these are set,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,12 +25,9 @@ jobs:
           --channel bioconda \
           --strict-channel-priority
 
-    # Build docs here
-    - name: build docs
+    - name: restrict number of built recipes
+      if: ${{ (github.ref != 'refs/heads/main') }}
       run: |
-        eval "$(conda shell.bash hook)"
-        conda activate ./env
-
         # For testing, use BIOCONDA_FILTER_RECIPES=10 or some small-ish number,
         # or BIOCONDA_FILTER_RECIPES=".*" or other regex. If these are set,
         # you'll get warnings like "Problem in conda domain: field is supposed
@@ -39,7 +36,13 @@ jobs:
         #
         # If unset, pages will be built for all recipes.
         # export BIOCONDA_FILTER_RECIPES=10
+        echo "BIOCONDA_FILTER_RECIPES=10" >> $GITHUB_ENV
 
+    - name: build docs
+      run: |
+        eval "$(conda shell.bash hook)"
+        export BIOCONDA_FILTER_RECIPES=${{env.BIOCONDA_FILTER_RECIPES}}
+        conda activate ./env
         make clean html SPHINXOPTS="-T -j1"
         touch build/html/.nojekyll
         tar -czf docs.tar.gz build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ jobs:
           (!contains(github.event.head_commit.message, '[build all recipes]'))
         }}
       run: |
+
         # For testing, use BIOCONDA_FILTER_RECIPES=10 or some small-ish number,
         # or BIOCONDA_FILTER_RECIPES=".*" or other regex. If these are set,
         # you'll get warnings like "Problem in conda domain: field is supposed

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,10 @@ jobs:
         # export BIOCONDA_FILTER_RECIPES=10
         echo "BIOCONDA_FILTER_RECIPES=10" >> $GITHUB_ENV
 
+    - name: override built recipe restriction with [build all recipes]
+      if: "contains(github.event.head_commit.message, '[build all recipes]'"
+        echo "BIOCONDA_FILTER_RECIPES=" >> $GITHUB_ENV
+
     - name: build docs
       run: |
         eval "$(conda shell.bash hook)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,6 @@ jobs:
     - name: build docs
       run: |
         eval "$(conda shell.bash hook)"
-        echo nonexistent is "${{env.NONEXISTENT}}"
         export BIOCONDA_FILTER_RECIPES=${{env.BIOCONDA_FILTER_RECIPES}}
         conda activate ./env
         make clean html SPHINXOPTS="-T -j1"


### PR DESCRIPTION
In order to speed up the process for building and inspecting docs, only build the README files for 10 recipes when the build occurs on any branch except `main`.