### PR TITLE
Update broken links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: docs
 on:
+  pull_request:
   push:
   schedule:
     - cron: '40 14 * * *'

--- a/source/_ext/bioconda_sphinx_ext.py
+++ b/source/_ext/bioconda_sphinx_ext.py
@@ -738,15 +738,18 @@ def add_ribbon(app, pagename, templatename, context, doctree):
         _, _, path = pagename.partition('/')
         path = path.replace('.', '/') + '.py'
         repo = 'bioconda-utils'
+        branch = 'master'
     elif pagename.startswith('recipes/') and pagename.endswith('/README'):
         repo = 'bioconda-recipes'
         path = pagename[:-len('README')] + 'meta.yaml'
+        branch = 'master'
     else:
-        repo = 'bioconda-utils'
-        path = 'docs/source/' + os.path.relpath(doctree.get('source'), app.builder.srcdir)
+        repo = 'bioconda-docs'
+        path = 'source/' + os.path.relpath(doctree.get('source'), app.builder.srcdir)
+        branch = 'main'
 
     context['git_ribbon_url'] = (f'https://github.com/bioconda/{repo}/'
-                                 f'edit/master/{path}')
+                                 f'edit/{branch}/{path}')
     context['git_ribbon_message'] = "Edit me on GitHub"
 
 

--- a/source/contributor/guidelines.rst
+++ b/source/contributor/guidelines.rst
@@ -523,7 +523,7 @@ for an example of this.
 
 Metapackages
 ------------
-`Metapackages <http://conda.pydata.org/docs/building/meta-pkg.html>`_ tie
+`Metapackages <https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html#metapackages>`_ tie
 together other packages. All they do is define dependencies. For example, the
 `hubward-all
 <https://github.com/bioconda/bioconda-recipes/tree/master/recipes/hubward-all>`_

--- a/source/developer/bulk.rst
+++ b/source/developer/bulk.rst
@@ -68,7 +68,7 @@ example is updating pinnings to support Python 3.10.
 
 3. Update ``common.sh`` (see `here
    <https://github.com/bioconda/bioconda-common/blob/master/common.sh>`_) **only on the bulk
-   branch in bioconda-commont**, to match the newly-updated bioconda-utils
+   branch in bioconda-common**, to match the newly-updated bioconda-utils
    version. Changing the pinnings will likely trigger many recipes to require
    rebuilding. Since the bioconda-recipes/bulk branch reads from the
    bioconda-common/bulk branch, this allows bulk to run a different version of

--- a/source/developer/repodata_patching.rst
+++ b/source/developer/repodata_patching.rst
@@ -18,7 +18,7 @@ What is repodata?
 Repodata is a JSON file that contains a variety of information for each package
 in Bioconda. There is one for each architecture (linux-64, osx-64, noarch, etc.)
 and they're hosted by bioconda. For example, the noarch repodata.json file `is
-available here<https://conda.anaconda.org/bioconda/noarch/repodata.json>`_.
+available here <https://conda.anaconda.org/bioconda/noarch/repodata.json>`_.
 Let's take a look at the what sorts of things are stored within this file for a
 single package:
 


### PR DESCRIPTION
Fix some broken links and typos, including the github banner which was pointing to the old location in the bioconda-utils repo.