### PR TITLE
Fix "micrpmamba" typo in readme.rst_t template

### DIFF
--- a/source/templates/readme.rst_t
+++ b/source/templates/readme.rst_t
@@ -67,7 +67,7 @@
    .. rubric:: Installation
 
   You need a conda-compatible package manager
-  (currently either `micrpmamba <https://mamba.readthedocs.io>`_, `mamba <https://mamba.readthedocs.io>`_, or `conda <https://docs.conda.io/projects/conda>`_)
+  (currently either `micromamba <https://mamba.readthedocs.io>`_, `mamba <https://mamba.readthedocs.io>`_, or `conda <https://docs.conda.io/projects/conda>`_)
   and the Bioconda channel already activated (see :ref:`set-up-channels`).
 
   While any of above package managers is fine, it is currently recommended to use either


### PR DESCRIPTION
Introduced in https://github.com/bioconda/bioconda-docs/commit/c91db1721eeefe7661f6b5b2dbb7fdac1fb80b2e