### PR TITLE
Rely on "run exports" to install zlib at runtime

### DIFF
--- a/source/contributor/cb3.rst
+++ b/source/contributor/cb3.rst
@@ -206,7 +206,7 @@ is used as a build dependency, it should also be automatically be installed as
 a run dependency without having to explicitly add it as such in the recipe.
 This specification is done in the ``zlib`` recipe itself (which is hosted by
 conda-forge), so in general bioconda collaborators can just add ``zlib`` as
-a build dependency.
+a host dependency.
 
 Note that we don't have to specify the version of ``zlib`` in the recipe -- it
 is pinned in that ``conda_build_config.yaml`` file we share with conda-forge.
@@ -248,7 +248,6 @@ After:
         - zlib
       run:
         - python
-        - zlib
 
 
 .. seealso::


### PR DESCRIPTION
I recently had a colleague get confused about "run exports" after reading the documentation page on [migrating to conda build v3](https://bioconda.github.io/contributor/cb3.html). I think the explanation of how to handle the `zlib` requirement is confusing.

Currently the text contains this explanation:

https://github.com/bioconda/bioconda-docs/blob/63664163701e4a71c1fe767e81b6110fddcf4a61/source/contributor/cb3.rst?plain=1#L203-L209

The first thing I noticed is that `zlib` shouldn't be added to `build`, since it doesn't have "strong run exports". Instead it should be added to  `host`.

Then in the example recipe, `zlib` is still added in `run`, which contradicts the paragraph about run exports

https://github.com/bioconda/bioconda-docs/blob/63664163701e4a71c1fe767e81b6110fddcf4a61/source/contributor/cb3.rst?plain=1#L246-L251

I suspect that part of the confusion is that `zlib` is itself a complex example of "run exports", which I will explain below. For documentation purposes, it might be better to simply include a more straight-forward example, and then tackle `zlib` since it is such a common requirement for bioconda recipes.

Here is why I think `zlib` is a complex example to demonstrate the concept of "run exports"

* This documentation was written way back in 2018 (https://github.com/bioconda/bioconda-utils/commit/d67288bf152dc0642b9e4cadb56956b9a9bffa66)
* In 2018, the zlib "run exports" was correct, and thus `zlib` should not have appeared in the `run` requirements in this example (https://github.com/conda-forge/zlib-feedstock/blob/b8a90e7d70a09d6672b559ac3bd027cc1f3019fa/recipe/meta.yaml#L17)
* However, the zlib-feedstock recipe has undergone some rearrangements, and at some point the "run exports" was broken and had to be added back in 2021 (https://github.com/conda-forge/zlib-feedstock/pull/53)
* The "run exports" doesn't follow the canonical pattern of exporting the same package at runtime. Instead it exports `libzlib` (https://github.com/conda-forge/zlib-feedstock/blob/649df646085a23f9f580418c1ca01249e151857b/recipe/meta.yaml#L77)
* It's my understanding that only exporting `libzlib` should be sufficient for software that properly links against `libzlib`. However, some software out in the wild still requires the files provided by `zlib` at runtime. Therefore, there are some cases where you would need to put `zlib` in both `host` and `run`. See this Issue for the details: https://github.com/conda-forge/zlib-feedstock/issues/65

Lastly, I'd note that there are many existing bioconda recipes that include `zlib` in the `run` requirements (https://github.com/search?q=repo%3Abioconda%2Fbioconda-recipes+zlib+language%3AYAML&type=code&l=YAML). If it's a bioconda convention to include `zlib` in `run` (perhaps to avoid the complexity I noted above), then I definitely think a different example should be chosen to demonstrate the concept of "run exports"