### PR TITLE
Update ci-inventory.rst - add `64` to `linux-aarch`

### DIFF
--- a/source/developer/ci-inventory.rst
+++ b/source/developer/ci-inventory.rst
@@ -71,7 +71,7 @@ maintain flexibility over the long term in case a service becomes unusable.
       - on push
       - `azure-pipeline.yml <https://github.com/bioconda/bioconda-recipes/blob/master/azure-pipeline.yml>`_ (``linux-64``, ``osx-64``);
         `config.yml <https://github.com/bioconda/bioconda-recipes/blob/master/.circleci/config.yml>`_ (``linux-aarch64``)
-      - ``linux-64``, ``osx-64``, ``linux-aarch``
+      - ``linux-64``, ``osx-64``, ``linux-aarch64``
       - These are the most-run tests: these are what run on every change on
         pull requests to bioconda-recipes, and they must pass before the recipe
         is merged into the master branch.


### PR DESCRIPTION
Noticed it at https://bioconda.github.io/developer/ci-inventory.html