### PR TITLE
doc: mention that .mambarc channels are ignored

### DIFF
--- a/source/contributor/building-locally.rst
+++ b/source/contributor/building-locally.rst
@@ -51,6 +51,9 @@ The above commands do the following:
      the recipes test in a clean, freshly created docker container to
      ensure that the package does not depend on anything that happens
      to be included in the build container.
+   - Make sure you have `bioconda` and `conda-forge` channels explicitly
+     added to your environment or your `.condarc`. It is not sufficient
+     to have those channels specified in `.mambarc`.
 
 If you do not have access to Docker, you can still run the basic test by
 omitting the ``--docker`` and ``--mulled-test`` options.


### PR DESCRIPTION
As someone who uses mamba for everything, I didn't realize I had to manually add conda-forge and bioconda channels to `.condarc`

The fact that there's no debug logging for conda possible through bioconda-utils made debugging harder, so this note could help others in the future who similarly use .mambarc but not .condarc

Related to https://github.com/bioconda/bioconda-utils/issues/1006