### PR TITLE
feat: display platform plot on package doc

### DIFF
--- a/source/templates/package_dashboard.html
+++ b/source/templates/package_dashboard.html
@@ -1,4 +1,5 @@
 <div style="width: 100%" id="download_plot"></div>
+<div style="width: 100%" id="platform_plot"></div>
 <div style="width: 100%" id="cdf_plot"></div>
 
 <script>
@@ -45,6 +46,24 @@
             vegaEmbed('#download_plot', spec);
         } catch (err) {
             console.error("An error occurred while building downloads plot: ", err)
+        }
+
+        // Build platform download plot
+        try {
+            const spec_resp = await fetch("https://raw.githubusercontent.com/bioconda/bioconda-plots/main/resources/platforms.vl.json")
+            if (!spec_resp.ok) {
+                throw new Error(`Fetching failed with HTTP code ${spec_resp.status}.`);
+            }
+            const spec = await spec_resp.json();
+            const platform_data_resp = await fetch(`https://raw.githubusercontent.com/bioconda/bioconda-plots/main/plots/${package}/platforms.json`)
+            if (!platform_data_resp.ok) {
+                throw new Error(`Fetching failed with HTTP code ${platform_data_resp.status}.`);
+            }
+            const plot_data = await platform_data_resp.json();
+            spec.data.values = plot_data;
+            vegaEmbed('#platform_plot', spec);
+        } catch (err) {
+            console.error("An error occurred while building platform downloads plot: ", err)
         }
   
     }


### PR DESCRIPTION
Adding new plot from https://github.com/bioconda/bioconda-stats/pull/4 and https://github.com/bioconda/bioconda-plots/pull/8 to the package page.

This just pulls the data and Vega configuration from bioconda-plots.

We only have 3 days of platform stats, so the bars are a bit wide. After 15 days it will line up with the version plot. 