### PR TITLE
remove defaults channel

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -30,7 +30,6 @@ First, `install conda`_.
 Then perform a one-time set up of Bioconda with the following commands. This
 will modify your :file:`~/.condarc` file::
 
-    conda config --add channels defaults
     conda config --add channels bioconda
     conda config --add channels conda-forge
     conda config --set channel_priority strict


### PR DESCRIPTION
We should have removed this one a long time ago. It was not used effectively, since it was the lowest priority, but it transferred a wrong message.