### PR TITLE
ci: Update docs.yml to allow manual dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: docs
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
It's nice to manually run immediately after someone points out that GitHub disabled the workflow.