### PR TITLE
Fix the inter Sphinx mappings for Conda urls

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -300,9 +300,9 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "conda.io": ("https://conda.io/en/latest", None),
-    "conda-build": ("https://conda.io/projects/conda-build/en/latest/", None),
-    "conda": ("https://conda.io/projects/conda/en/latest/", None),
+    "conda.io": ("https://docs.conda.io/en/latest", None),
+    "conda-build": ("https://docs.conda.io/projects/conda-build/en/latest/", None),
+    "conda": ("https://docs.conda.io/projects/conda/en/latest/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
 


### PR DESCRIPTION
Fixes the following warnings:
```
loading intersphinx inventory 'conda.io' from https://conda.io/en/latest/objects.inv ...
loading intersphinx inventory 'conda-build' from https://conda.io/projects/conda-build/en/latest/objects.inv ...
loading intersphinx inventory 'conda' from https://conda.io/projects/conda/en/latest/objects.inv ...
intersphinx inventory has moved: https://conda.io/en/latest/objects.inv -> https://docs.conda.io/en/latest/objects.inv
intersphinx inventory has moved: https://conda.io/projects/conda/en/latest/objects.inv -> https://docs.conda.io/projects/conda/en/latest/objects.inv
intersphinx inventory has moved: https://conda.io/projects/conda-build/en/latest/objects.inv -> https://docs.conda.io/projects/conda-build/en/latest/objects.inv
```