### PR TITLE
Issue #34 - Print the additional platforms in the `description` table column

### DIFF
--- a/source/_ext/bioconda_sphinx_ext.py
+++ b/source/_ext/bioconda_sphinx_ext.py
@@ -394,23 +394,22 @@ class PackageIndex(Index):
 
     def generate(self, docnames: Optional[List[str]] = None):
         """build index"""
-        content = {}
+        content = []
 
         objects = sorted(self.domain.data['objects'].items())
         for (typ, name), (docname, labelid, description) in objects:
             if docnames and docname not in docnames:
                 continue
-            entries = content.setdefault(name[0].lower(), [])
-            subtype = 0 # 1 has subentries, 2 is subentry
-            entries.append((
-                # TODO: Add meaningful info for extra/qualifier/description
-                #       fields, e.g., latest package version.
-                # name, subtype, docname, labelid, 'extra', 'qualifier', 'description',
-                name, subtype, docname, labelid, '', '', description,
-            ))
+
+            # TODO: Add meaningful info for extra/qualifier/description
+            #       fields, e.g., latest package version.
+            content.append({
+                "name": name,
+                "archs": description
+            })
 
         collapse = True
-        return sorted(content.items()), collapse
+        return content, collapse
 
 
 class CondaDomain(Domain):
@@ -609,7 +608,10 @@ def generate_readme(recipe_basedir, output_dir, folder, repodata, renderer):
         'packages': packages,
     }
 
-    recipe_additional_platforms[recipe.name] = ', '.join(recipe_extra.get('additional-platforms', []))
+    if recipe_extra is None:
+        recipe_additional_platforms[recipe.name] = ''
+    else:
+        recipe_additional_platforms[recipe.name] = ', '.join(recipe_extra.get('additional-platforms', []))
 
     renderer.render_to_file(output_file, 'readme.rst_t', template_options)
     return [output_file]

--- a/source/_ext/bioconda_sphinx_ext.py
+++ b/source/_ext/bioconda_sphinx_ext.py
@@ -404,12 +404,21 @@ class PackageIndex(Index):
 
             recipe_details = recipes_details.get(name, {})
             
+            platforms = []
+            noarch = recipe_details.get('noarch')
+            if noarch:
+                platforms.append("noarch (%s)" % noarch)
+
+            additional_platforms = recipe_details.get('additional-platforms', [])
+            if len(additional_platforms) > 0:
+                platforms.extend(additional_platforms)
+
             # TODO: Add meaningful info for extra/qualifier/description
             #       fields, e.g., latest package version.
             content.append({
                 "name": name,
-                "additional-platforms": ', '.join(recipe_details.get('additional-platforms', [])),
-                "latest-version": recipe_details.get('latest-version')
+                "additional_platforms": ', '.join(platforms),
+                "latest_version": recipe_details.get('latest_version')
             })
 
         collapse = True
@@ -577,6 +586,8 @@ def generate_readme(recipe_basedir, output_dir, folder, repodata, renderer):
         return []
 
     recipe_details = recipes_details.get(recipe.name, {})
+    
+    recipe_details['noarch'] = recipe.meta["build"].get("noarch", '')
 
     # Format the README
     packages = []
@@ -598,7 +609,7 @@ def generate_readme(recipe_basedir, output_dir, folder, repodata, renderer):
             ]
 
             if recipe.name == package:
-                recipe_details['latest-version'] = sorted_versions[0][0]
+                recipe_details['latest_version'] = sorted_versions[0][0]
                 # recipe_details['build_number'] = sorted_versions[0][1]
         else:
             depends = []

--- a/source/templates/domainindex.html
+++ b/source/templates/domainindex.html
@@ -54,7 +54,7 @@
 
     let dataset = [
         {%- for (entry) in content %}
-        ["{{ entry.name }}", "{{ entry.archs }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
+        ["{{ entry.name }}", "{{ entry['latest-version'] }}", "{{ entry['additional-platforms'] }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
         {%- endfor %}
     ];
 
@@ -62,10 +62,10 @@
     let arm64Count = 0;
     for (let i=0; i<dataset.length; i++) {
       let entry = dataset[i];
-      if (entry[1].includes("linux-aarch64")) {
+      if (entry[2].includes("linux-aarch64")) {
         aarch64Count += 1;
       }
-      if (entry[1].includes("osx-arm64")) {
+      if (entry[2].includes("osx-arm64")) {
         arm64Count += 1;
       }
     }
@@ -80,7 +80,11 @@
       data: dataset,
       columns: [
         { title: "Name" },
-        { 
+        {
+            title: "Latest version",
+            orderable: false
+        },
+        {
             title: "Additional platforms",
             orderable: false
         },

--- a/source/templates/domainindex.html
+++ b/source/templates/domainindex.html
@@ -36,6 +36,11 @@
         <td></td>
       </tr>
       <tr>
+        <td>noarch</td>
+        <td id="noarch-count" style="text-align: center;"></td>
+        <td><span id="noarch-ratio"></span>%</td>
+      </tr>
+      <tr>
         <td>linux-aarch64</td>
         <td id="linux-aarch64-count" style="text-align: center;"></td>
         <td><span id="linux-aarch64-ratio"></span>%</td>
@@ -54,12 +59,13 @@
 
     let dataset = [
         {%- for (entry) in content %}
-        ["{{ entry.name }}", "{{ entry['latest-version'] }}", "{{ entry['additional-platforms'] }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
+        ["{{ entry.name }}", "{{ entry.latest_version }}", "{{ entry.additional_platforms }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
         {%- endfor %}
     ];
 
     let aarch64Count = 0;
     let arm64Count = 0;
+    let noarchCount = 0;
     for (let i=0; i<dataset.length; i++) {
       let entry = dataset[i];
       if (entry[2].includes("linux-aarch64")) {
@@ -68,8 +74,13 @@
       if (entry[2].includes("osx-arm64")) {
         arm64Count += 1;
       }
+      if (entry[2].includes("noarch")) {
+        noarchCount += 1;
+      }
     }
     let totalCount = dataset.length;
+    document.getElementById("noarch-count").textContent = noarchCount;
+    document.getElementById("noarch-ratio").textContent = (noarchCount / totalCount * 100).toFixed(2);
     document.getElementById("linux-aarch64-count").textContent = aarch64Count;
     document.getElementById("linux-aarch64-ratio").textContent = (aarch64Count / totalCount * 100).toFixed(2);
     document.getElementById("osx-arm64-count").textContent = arm64Count;

--- a/source/templates/domainindex.html
+++ b/source/templates/domainindex.html
@@ -1,0 +1,102 @@
+{# Template for domain indices (module index, ...). #}
+{%- extends "layout.html" %}
+{% set title = indextitle %}
+{% block extrahead %}
+{{ super() }}
+{% if not embedded and collapse_index %}
+    <script>
+      DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true;
+    </script>
+{% endif %}
+  <link rel="stylesheet" href="https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css" />
+  <link rel="stylesheet" href="https://cdn.datatables.net/rowgroup/1.5.1/css/rowGroup.dataTables.min.css"/>
+    
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
+  <script src="https://cdn.datatables.net/rowgroup/1.5.1/js/dataTables.rowGroup.min.js"></script>
+{% endblock %}
+{% block body %}
+
+   {%- set groupid = idgen() %}
+
+   <h1>{{ indextitle }}</h1>
+   
+   <table>
+    <thead>
+      <tr>
+        <th></th>
+        <th>Count</th>
+        <th>Ratio</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Total recipes:</td>
+        <td id="total-count"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>linux-aarch64 recipes:</td>
+        <td id="linux-aarch64-count"></td>
+        <td><span id="linux-aarch64-ratio"></span>%</td>
+      </tr>
+      <tr>
+        <td>osx-arm64 recipes:</td>
+        <td id="osx-arm64-count"></td>
+        <td><span id="osx-arm64-ratio"></span>%</td>
+      </tr>
+    </tbody>
+   </table>
+   
+   <table class="indextable modindextable" id="recipes-table"></table>
+   
+   <script>
+
+    let dataset = [
+        {%- for (entry) in content %}
+        ["{{ entry.name }}", "{{ entry.archs }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
+        {%- endfor %}
+    ];
+
+    let aarch64Count = 0;
+    let arm64Count = 0;
+    for (let i=0; i<dataset.length; i++) {
+      let entry = dataset[i];
+      if (entry[1].includes("linux-aarch64")) {
+        aarch64Count += 1;
+      }
+      if (entry[1].includes("osx-arm64")) {
+        arm64Count += 1;
+      }
+    }
+    let totalCount = dataset.length;
+    document.getElementById("linux-aarch64-count").textContent = aarch64Count;
+    document.getElementById("linux-aarch64-ratio").textContent = (aarch64Count / totalCount * 100).toFixed(2);
+    document.getElementById("osx-arm64-count").textContent = arm64Count;
+    document.getElementById("osx-arm64-ratio").textContent = (arm64Count / totalCount * 100).toFixed(2);
+    document.getElementById("total-count").textContent = totalCount;
+
+    let table = new DataTable('#recipes-table', {
+      data: dataset,
+      columns: [
+        { title: "Name" },
+        { 
+            title: "Additional platforms",
+            orderable: false
+        },
+      ],
+      displayLength: 25,
+      lengthMenu: [
+        [10, 25, 50, -1],
+        [10, 25, 50, 'All']
+      ],
+      rowGroup: {
+        enable: true,
+        dataSrc: function(row) {
+          return row[0].charAt(0).toLowerCase();
+        }
+      }
+    });
+   </script>
+
+{% endblock %}

--- a/source/templates/domainindex.html
+++ b/source/templates/domainindex.html
@@ -41,9 +41,19 @@
         <td><span id="noarch-ratio"></span>%</td>
       </tr>
       <tr>
+        <td>linux-64</td>
+        <td id="linux-64-count" style="text-align: center;"></td>
+        <td><span id="linux-64-ratio"></span>%</td>
+      </tr>
+      <tr>
         <td>linux-aarch64</td>
         <td id="linux-aarch64-count" style="text-align: center;"></td>
         <td><span id="linux-aarch64-ratio"></span>%</td>
+      </tr>
+      <tr>
+        <td>osx-64:</td>
+        <td id="osx-64-count" style="text-align: center;"></td>
+        <td><span id="osx-64-ratio"></span>%</td>
       </tr>
       <tr>
         <td>osx-arm64:</td>
@@ -59,20 +69,28 @@
 
     let dataset = [
         {%- for (entry) in content %}
-        ["{{ entry.name }}", "{{ entry.latest_version }}", "{{ entry.additional_platforms }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
+        ["{{ entry.name }}", "{{ entry.latest_version }}", "{{ entry.platforms }}"]{%- if not loop.last -%}{{ "," }}{%- endif -%} 
         {%- endfor %}
     ];
 
-    let aarch64Count = 0;
-    let arm64Count = 0;
+    let linux64Count = 0;
+    let linuxAarch64Count = 0;
+    let osx64Count = 0;
+    let osxArm64Count = 0;
     let noarchCount = 0;
     for (let i=0; i<dataset.length; i++) {
       let entry = dataset[i];
+      if (entry[2].includes("linux-64")) {
+        linux64Count += 1;
+      }
       if (entry[2].includes("linux-aarch64")) {
-        aarch64Count += 1;
+        linuxAarch64Count += 1;
+      }
+      if (entry[2].includes("osx-64")) {
+        osx64Count += 1;
       }
       if (entry[2].includes("osx-arm64")) {
-        arm64Count += 1;
+        osxArm64Count += 1;
       }
       if (entry[2].includes("noarch")) {
         noarchCount += 1;
@@ -81,10 +99,14 @@
     let totalCount = dataset.length;
     document.getElementById("noarch-count").textContent = noarchCount;
     document.getElementById("noarch-ratio").textContent = (noarchCount / totalCount * 100).toFixed(2);
-    document.getElementById("linux-aarch64-count").textContent = aarch64Count;
-    document.getElementById("linux-aarch64-ratio").textContent = (aarch64Count / totalCount * 100).toFixed(2);
-    document.getElementById("osx-arm64-count").textContent = arm64Count;
-    document.getElementById("osx-arm64-ratio").textContent = (arm64Count / totalCount * 100).toFixed(2);
+    document.getElementById("linux-64-count").textContent = linux64Count;
+    document.getElementById("linux-64-ratio").textContent = (linux64Count / totalCount * 100).toFixed(2);
+    document.getElementById("linux-aarch64-count").textContent = linuxAarch64Count;
+    document.getElementById("linux-aarch64-ratio").textContent = (linuxAarch64Count / totalCount * 100).toFixed(2);
+    document.getElementById("osx-64-count").textContent = osx64Count;
+    document.getElementById("osx-64-ratio").textContent = (osx64Count / totalCount * 100).toFixed(2);
+    document.getElementById("osx-arm64-count").textContent = osxArm64Count;
+    document.getElementById("osx-arm64-ratio").textContent = (osxArm64Count / totalCount * 100).toFixed(2);
     document.getElementById("total-count").textContent = totalCount;
 
     let table = new DataTable('#recipes-table', {
@@ -96,7 +118,7 @@
             orderable: false
         },
         {
-            title: "Additional platforms",
+            title: "Platforms",
             orderable: false
         },
       ],

--- a/source/templates/domainindex.html
+++ b/source/templates/domainindex.html
@@ -89,25 +89,22 @@
             orderable: false
         },
       ],
-      displayLength: 25,
+      displayLength: 50,
       lengthMenu: [
-        [10, 25, 50, -1],
-        [10, 25, 50, 'All']
+        [10, 50, 100, -1],
+        [10, 50, 100, 'All']
       ],
       columnDefs: [
         {
             render: (data, type, row) => {
-              console.log(data, type, row);
-              return '<a href="./recipes/' + data + '/README.html#package-'+data+'"><code class="xref">' + data + '</code></a>'
-          },
+              return '<a href="./recipes/' + data + '/README.html#package-'+data+'"><code class="xref">' + data + '</code></a>';
+            },
             targets: 0
         },
       ],
       rowGroup: {
         enable: true,
-        dataSrc: function(row) {
-          return row[0].charAt(0).toLowerCase();
-        }
+        dataSrc: (row) => row[0].charAt(0).toLowerCase()
       }
     });
    </script>

--- a/source/templates/domainindex.html
+++ b/source/templates/domainindex.html
@@ -24,25 +24,25 @@
    <table>
     <thead>
       <tr>
-        <th></th>
+        <th>Recipes</th>
         <th>Count</th>
         <th>Ratio</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>Total recipes:</td>
-        <td id="total-count"></td>
+        <td>Total</td>
+        <td id="total-count" style="text-align: center;"></td>
         <td></td>
       </tr>
       <tr>
-        <td>linux-aarch64 recipes:</td>
-        <td id="linux-aarch64-count"></td>
+        <td>linux-aarch64</td>
+        <td id="linux-aarch64-count" style="text-align: center;"></td>
         <td><span id="linux-aarch64-ratio"></span>%</td>
       </tr>
       <tr>
-        <td>osx-arm64 recipes:</td>
-        <td id="osx-arm64-count"></td>
+        <td>osx-arm64:</td>
+        <td id="osx-arm64-count" style="text-align: center;"></td>
         <td><span id="osx-arm64-ratio"></span>%</td>
       </tr>
     </tbody>
@@ -93,6 +93,15 @@
       lengthMenu: [
         [10, 25, 50, -1],
         [10, 25, 50, 'All']
+      ],
+      columnDefs: [
+        {
+            render: (data, type, row) => {
+              console.log(data, type, row);
+              return '<a href="./recipes/' + data + '/README.html#package-'+data+'"><code class="xref">' + data + '</code></a>'
+          },
+            targets: 0
+        },
       ],
       rowGroup: {
         enable: true,

--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -34,11 +34,13 @@
     let closest;
     // Get the last part of the URL after the # symbol - should match the div id to display
     let id = window.location.hash.substring(1);
-    let elem = document.getElementById(id);
-    if (elem != null) {
-        // Get the closest "details" element and open it
-        closest = elem.closest("details");
-        if (closest) closest.open = true;
+    if (id) {
+        let elem = document.getElementById(id);
+        if (elem != null) {
+            // Get the closest "details" element and open it
+            closest = elem.closest("details");
+            if (closest) closest.open = true;
+        }
     }
 </script>
 

--- a/source/templates/readme.rst_t
+++ b/source/templates/readme.rst_t
@@ -64,6 +64,20 @@
    {%- endfor %}
    :requirements:
 
+   :additional platforms:
+      {% if extra and extra['additional-platforms']|length > 0 %}
+      .. raw:: html
+
+         <span class="additional-platforms">
+         {%- for platform in extra['additional-platforms'] -%}
+            <code>{{ platform }}</code>
+            {%- if not loop.last -%}
+               {{ ",\xa0 " }}
+            {%- endif -%}
+         {%- endfor -%}
+         </span>
+      {% endif %}
+
    .. rubric:: Installation
 
   You need a conda-compatible package manager


### PR DESCRIPTION
Prints the optional additional platforms in the `description` column of the Index table.
Also prints the platforms in the recipe's details page.

![recipe-details](https://github.com/user-attachments/assets/ac8cdee7-6733-44c1-94c2-689fbafda704)
![index-page](https://github.com/user-attachments/assets/f4ebd5ff-105a-42d2-8ddd-bcefbc6e567d)


~This is still work in progress! I'll try to make the Index table more dynamic by using https://datatables.net/~