### PR TITLE
Remove defaults channel from info boxes and tutorials

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -45,21 +45,20 @@ settings follow the current recommendations.
     channel_priority_strict`` was added; see the `explanation of commands below
     <#explain-commands>`_ for details.
 
+    In August 2024, the ``defaults`` channel was removed from the recommended
+    set of channels.
+
 .. details:: What did these commands do?
     :anchor: explain-commands
 
     In general, running ``conda config`` modifies your condarc file which can be
     found at ``~/.condarc`` by default.
 
-    The first three commands add channels, from lowest to highest priority.
+    The first two commands add channels, from lowest to highest priority.
     **The order is important** to avoid problems with solving dependencies::
 
-        conda config --add channels defaults
         conda config --add channels bioconda
         conda config --add channels conda-forge
-
-    - The ``defaults`` channel is the one set by default in a new installation of
-      conda. It should be set to the lowest priority.
 
     - The ``bioconda`` channel enables installation of packages related to
       biomedical research.
@@ -97,7 +96,6 @@ settings follow the current recommendations.
         conda create -n myenv samtools bwa \
           --channel conda-forge \
           --channel bioconda \
-          --channel defaults \
           --strict-channel-priority
 
     Note that conda interprets channels on the command line in order

--- a/source/tutorials/2024-adding-bioinformatic-software-to-bioconda.rst
+++ b/source/tutorials/2024-adding-bioinformatic-software-to-bioconda.rst
@@ -59,7 +59,7 @@ TL;DR Relevant Commands
     ## Option 2: bioconda-utils
     docker run -t --net host --rm -v /tmp/tmp<randomletters>/build_script.bash:/opt/build_script.bash -v /<path>/<to>/<conda-install>/envs/<toolname>/conda-bld/:/opt/host-conda-bld -v /<path>/<to>/<recipes_local_clone>/recipes/<toolname>:/opt/recipe -e LC_ADDRESS=en_GB.UTF-8 -e LC_NAME=en_GB.UTF-8 -e LC_MONETARY=en_GB.UTF-8 -e LC_PAPER=en_GB.UTF-8 -e LANG=en_GB.UTF-8 -e LC_IDENTIFICATION=en_GB.UTF-8 -e LC_TELEPHONE=en_GB.UTF-8 -e LC_MEASUREMENT=en_GB.UTF-8 -e LC_TIME=en_GB.UTF-8 -e LC_NUMERIC=en_GB.UTF-8 -e HOST_USER_ID=1000 quay.io/bioconda/bioconda-utils-build-env-cos7:2.11.1 bash
 
-    conda mambabuild -c file:///opt/host-conda-bld --override-channels --no-anaconda-upload -c conda-forge -c bioconda -c defaults -e /opt/host-conda-bld/conda_build_config_0_-e_conda_build_config.yaml -e /opt/host-conda-bld/conda_build_config_1_-e_bioconda_utils-conda_build_config.yaml /opt/recipe/meta.yaml 2>&1
+    conda mambabuild -c file:///opt/host-conda-bld --override-channels --no-anaconda-upload -c conda-forge -c bioconda -e /opt/host-conda-bld/conda_build_config_0_-e_conda_build_config.yaml -e /opt/host-conda-bld/conda_build_config_1_-e_bioconda_utils-conda_build_config.yaml /opt/recipe/meta.yaml 2>&1
     conda activate /opt/conda/conda-bld/<toolname_hash>/_build_env
 
     ## Testing the Docker image artifact

--- a/source/tutorials/2024-debugging-bioinformatic-software-to-bioconda.rst
+++ b/source/tutorials/2024-debugging-bioinformatic-software-to-bioconda.rst
@@ -117,7 +117,7 @@ follow the *exact* steps the build process goes through:
 
    .. code:: bash
 
-      conda mambabuild -c file:///opt/host-conda-bld --override-channels --no-anaconda-upload -c conda-forge -c bioconda -c defaults -e /opt/host-conda-bld/conda_build_config_0_-e_conda_build_config.yaml -e /opt/host-conda-bld/conda_build_config_1_-e_bioconda_utils-conda_build_config.yaml /opt/recipe/meta.yaml 2>&1
+      conda mambabuild -c file:///opt/host-conda-bld --override-channels --no-anaconda-upload -c conda-forge -c bioconda -e /opt/host-conda-bld/conda_build_config_0_-e_conda_build_config.yaml -e /opt/host-conda-bld/conda_build_config_1_-e_bioconda_utils-conda_build_config.yaml /opt/recipe/meta.yaml 2>&1
 
    This is the primary command that runs the entire building of the
    recipe.


### PR DESCRIPTION
PR #30 removed `defaults` from the [main instructions](https://bioconda.github.io/), but did not remove it from the “What did these commands do?” box or add it to the “How have the recommendations changed?” box. This PR fixes that, and updates a couple of other occurrences.