### PR TITLE
Documentation of more dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Make an environment containing the `bioconda-utils` package. E.g.,
 mamba create \
   env -n bioconda-docs \
   bioconda-utils \
+  sphinx \
+  sphinx-autodoc-typehints \
+  celery \
   --channel conda-forge \
   --channel bioconda \
   --strict-channel-priority


### PR DESCRIPTION
I found that `make html` failed after running this:

  `conda create -n bioconda-docs -c conda-forge -c bioconda bioconda-utils && conda activate bioconda-docs`

I found that `make html` succeeded after running this:

  `conda create -n bioconda-docs -c conda-forge -c bioconda bioconda-utils sphinx sphinx-autodoc-typehints celery && conda activate bioconda-docs`