### PR TITLE
docs: document bioconda-utils auth

### DIFF
--- a/source/contributor/building-locally.rst
+++ b/source/contributor/building-locally.rst
@@ -33,7 +33,7 @@ You can install ``bioconda-utils`` locally by creating a new conda environment:
     bioconda-utils lint --git-range master HEAD
 
     # build and test
-    bioconda-utils build --docker --mulled-test --git-range master HEAD
+    bioconda-utils build --docker --mulled-build-and-test --git-range master HEAD
 
 The above commands do the following:
 
@@ -52,7 +52,7 @@ The above commands do the following:
    - The ``--docker`` flag instructs ``bioconda-utils`` to execute the
      build within a docker container. On MacOS, this will do a Linux
      build in addition to the local MacOS build.
-   - The ``--mulled-test`` flag instructs ``bioconda-utils`` to repeat
+   - The ``--mulled-build-and-test`` flag instructs ``bioconda-utils`` to repeat
      the recipes test in a clean, freshly created docker container to
      ensure that the package does not depend on anything that happens
      to be included in the build container.
@@ -61,7 +61,20 @@ The above commands do the following:
      to have those channels specified in `.mambarc`.
 
 If you do not have access to Docker, you can still run the basic test by
-omitting the ``--docker`` and ``--mulled-test`` options.
+omitting the ``--docker`` and ``--mulled-build-and-test`` options.
+
+.. note::
+
+   Some :program:`bioconda-utils` commands need credentials to interact with
+   remote services:
+
+   - Set ``QUAY_LOGIN`` (in ``user:password`` format) or ``QUAY_OAUTH_TOKEN``
+     (a Quay OAuth token) to authenticate with `quay.io
+     <https://quay.io/>`_ for publishing Biocontainers. :program:`bioconda-utils`
+     uses these environment variables when uploading container images.
+   - Set ``ANACONDA_TOKEN`` to authenticate with `anaconda.org
+     <https://anaconda.org>`_ for uploading packages or running
+     ``bioconda-utils duplicates --remove``.
 
 Other CLI Commands
 ~~~~~~~~~~~~~~~~~~~

--- a/source/contributor/building-locally.rst
+++ b/source/contributor/building-locally.rst
@@ -63,6 +63,8 @@ The above commands do the following:
 If you do not have access to Docker, you can still run the basic test by
 omitting the ``--docker`` and ``--mulled-build-and-test`` options.
 
+.. _credentials:
+
 .. note::
 
    Some :program:`bioconda-utils` commands need credentials to interact with

--- a/source/developer/dockerfile-inventory.rst
+++ b/source/developer/dockerfile-inventory.rst
@@ -37,7 +37,7 @@ architectures like osx, linux/amd64, linux/arm64, but also OCI images
 .. figure:: ../images/bioconda-containers.png
 
    Sketch of how containers and packages interact with :command:`bioconda-utils
-   build --docker --mulled-test`. See below for details. [:download:`excalidraw
+       build --docker --mulled-build-and-test`. See below for details. [:download:`excalidraw
    <../images/bioconda-containers.excalidraw>`] [:download:`SVG
    <../images/bioconda-containers.svg>`]
 
@@ -64,7 +64,7 @@ pkgname` in the bioconda-recipes repo.
    container are copied over into the :file:`/usr/local` dir of a minimal *base
    container* (which does not even include conda). The extracted tests are run
    in the container as a final check (see notes below on
-   :command:`--mulled-test`), and then the container is ready to upload to
+   :command:`--mulled-build-and-test`), and then the container is ready to upload to
    a container registry.
 
 Why do we do it this way? The short answer is to ensure that all dependencies
@@ -85,7 +85,7 @@ being used. As with a normal :command:`conda build` command, the resulting
 package is found in the host's :file:`conda-bld` directory. This is illustrated
 in steps 1-3 above.
 
-When we additionally use the :command:`--mulled-test` argument,
+When we additionally use the :command:`--mulled-build-and-test` argument,
 :program:`bioconda-utils` will run :program:`mulled-build` from the `galaxy-lib
 <https://galaxy-lib.readthedocs.io/en/latest/topics/mulled.html>`_ package.
 :program:`mulled-build` is a tool to convert conda packages into Docker images.
@@ -98,7 +98,7 @@ So the end result is a fully-isolated, minimal Docker image with nothing but
 the installed package and its dependencies (and therefore a small size), ready
 to be uploaded to a repository.
 
-Note that :command:`--mulled-test` runs the tests extracted from the recipe in
+Note that :command:`--mulled-build-and-test` runs the tests extracted from the recipe in
 the minimal container. Since the container only contains the package and its
 dependencies, any tests must use only these. Even if the recipe specifies
 additional test dependencies or additional test data (which is supported by
@@ -194,9 +194,15 @@ can give you a starting point for where to look.
 - mulled-build also needs a conda image to use. This is set by bioconda-utils
   in `pkg_test.py
   <https://github.com/bioconda/bioconda-utils/blob/2c5d4ad754f7bfa17b90495dc602118c7270d4bc/bioconda_utils/pkg_test.py#L20>`_
-  which is then passed to `build.build
-  <https://github.com/bioconda/bioconda-utils/blob/2c5d4ad754f7bfa17b90495dc602118c7270d4bc/bioconda_utils/build.py#L61>`_.
+which is then passed to `build.build
+   <https://github.com/bioconda/bioconda-utils/blob/2c5d4ad754f7bfa17b90495dc602118c7270d4bc/bioconda_utils/build.py#L61>`_.
 
+- Container registry credentials for uploading images to quay.io are configured
+  via environment variables. Set ``QUAY_LOGIN`` (in ``user:password`` format)
+  or ``QUAY_OAUTH_TOKEN`` (a Quay OAuth token). These are read by
+  ``bioconda_utils.container_manifests.registry_creds()`` and passed to
+  `skopeo <https://github.com/containers/skopeo>`_ and ``docker buildx`` for
+  authentication.
 
 The bot
 -------

--- a/source/developer/dockerfile-inventory.rst
+++ b/source/developer/dockerfile-inventory.rst
@@ -198,11 +198,7 @@ which is then passed to `build.build
    <https://github.com/bioconda/bioconda-utils/blob/2c5d4ad754f7bfa17b90495dc602118c7270d4bc/bioconda_utils/build.py#L61>`_.
 
 - Container registry credentials for uploading images to quay.io are configured
-  via environment variables. Set ``QUAY_LOGIN`` (in ``user:password`` format)
-  or ``QUAY_OAUTH_TOKEN`` (a Quay OAuth token). These are read by
-  ``bioconda_utils.container_manifests.registry_creds()`` and passed to
-  `skopeo <https://github.com/containers/skopeo>`_ and ``docker buildx`` for
-  authentication.
+  via environment variables (see :ref:`credentials` for details).
 
 The bot
 -------

--- a/source/tutorials/2024-adding-bioinformatic-software-to-bioconda.rst
+++ b/source/tutorials/2024-adding-bioinformatic-software-to-bioconda.rst
@@ -48,7 +48,7 @@ TL;DR Relevant Commands
     conda build recipes/<toolname>
 
     ## Option 2:
-    bioconda-utils build --docker --mulled-test --packages <toolname>
+    bioconda-utils build --docker --mulled-build-and-test --packages <toolname>
 
     ## Debugging
     ## Option 1: conda-build
@@ -356,7 +356,7 @@ Otherwise, in our Bioconda-build conda environment, we can run one of two option
 
   .. code-block:: bash
 
-    bioconda-utils build --docker --mulled-test --packages <toolname>
+    bioconda-utils build --docker --mulled-build-and-test --packages <toolname>
 
 
 Hopefully, if everything worked correctly the first time, we should have a successful build and we can proceed with submitting to bioconda.


### PR DESCRIPTION
This was previously undocumented. 
Also, mulled-test has been renamed in https://github.com/bioconda/bioconda-utils/pull/1115 , updates docs to fit the new name